### PR TITLE
Map -S mode buffers with MAP_PRIVATE

### DIFF
--- a/microbenchmark/README.md
+++ b/microbenchmark/README.md
@@ -18,7 +18,10 @@ This microbenchmark can be used to run with one thread for pointer-chasing or on
   ```
 
 ### Multi-process modes
-* Shared buffers across processes (`-S`, `-t`: number of processes)
+* Shared virtual address range across processes (`-S`, `-t`: number of processes)
+  * Buffers are mapped before `fork()` with `MAP_PRIVATE`, so each process
+    receives the same virtual addresses while keeping its own private copy of
+    the data.
   * Pointer-chasing
     ```
     ./bench -S -t 36 -R 0.0 -i 9 -A 1024

--- a/microbenchmark/src/main.c
+++ b/microbenchmark/src/main.c
@@ -265,14 +265,14 @@ int run_processes(header_t *header)
         if (pc_count > 0) {
             shared_a = mmap(NULL, header->buf_size_a * num_proc,
                             PROT_READ | PROT_WRITE,
-                            MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
             if (shared_a == MAP_FAILED)
                 return -1;
         }
         if (num_proc - pc_count > 0) {
             shared_b = mmap(NULL, header->buf_size_b * num_proc,
                             PROT_READ | PROT_WRITE,
-                            MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
             if (shared_b == MAP_FAILED)
                 return -1;
         }


### PR DESCRIPTION
## Summary
- Map multi-process `-S` buffers with `MAP_PRIVATE` to share only virtual addresses
- Document the revised `-S` mode behavior

## Testing
- `make clean && make`
- `./bench -S -t 2 -R 0.5 -i 1 -A 1 -B 1`


------
https://chatgpt.com/codex/tasks/task_e_688d7cc5616c8321b191cea6ed111310